### PR TITLE
ABU-945: Fix to stop bookmarking if spoor disabled

### DIFF
--- a/js/adapt-contrib-bookmarking.js
+++ b/js/adapt-contrib-bookmarking.js
@@ -52,6 +52,13 @@ define([
 
                 var courseBookmarkModel = Adapt.course.get('_bookmarking');
                 courseBookmarkModel._locationID = this.locationID;
+
+                try {
+                    var model = Adapt.findById(this.locationID);
+                } catch (error) {
+                    return;
+                }
+
                 this.showPrompt();
             }, this));
         },


### PR DESCRIPTION
- check if invalid location is returned from spoor and don't bookmark
- rest of this fix is in spoor @ https://github.com/adaptlearning/adapt-contrib-spoor/pull/72
