### PR TITLE
Add ability to exclude bookmarked element

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ The defaults set in *course.json* can be overridden for each contentObject of `"
 
 <div float align=right><a href="#top">Back to Top</a></div>
 
+#### Exclusion from bookmarking
+You can exclude from bookmarking elements specified at the `_level` property. You have to put there the `_bookmarking` property with `_isEnabled` set to false. If the `_level` is block then do this in the `blocks.json`.
+
 ## Limitations
  
 **Bookmarking** only works if [**Spoor**](https://github.com/adaptlearning/adapt-contrib-spoor) is enabled and the course is being presented in a learning management system (LMS). 

--- a/js/adapt-contrib-bookmarking.js
+++ b/js/adapt-contrib-bookmarking.js
@@ -157,6 +157,15 @@ define([
         setLocationID: function (id) {
             if (!Adapt.offlineStorage) return;
             if (this.currentLocationID == id) return;
+            if (id && id !== "") {
+                try {
+                    var model = Adapt.findById(id),
+                        bookmark = model ? model.get("_bookmarking") : undefined;
+                    if (bookmark && bookmark.hasOwnProperty("_isEnabled") && !bookmark._isEnabled) {
+                        return;//skip
+                    }
+                } catch (err) { console.error("Bookmarking#setLocationID", err); }
+            }
             Adapt.offlineStorage.set("location", id);
             this.currentLocationID = id;
         },

--- a/properties.schema
+++ b/properties.schema
@@ -111,12 +111,66 @@
         },
         "article": {
           "type":"object"
+          "properties":{
+            "_bookmarking": {
+              "type": "object",
+              "required": false,
+              "legend": "Bookmarking",
+              "properties": {
+                "_isEnabled": {
+                  "type": "boolean",
+                  "required":true,
+                  "default": false,
+                  "title": "Is enabled",
+                  "inputType": {"type": "Boolean", "options": [true, false]},
+                  "validators": [],
+                  "help": "If set to 'true', bookmarking will be turned on. Overrides bookmark setting for the course."
+                }
+              }
+            }
+          }
         },
         "block": {
           "type":"object"
+          "properties":{
+            "_bookmarking": {
+              "type": "object",
+              "required": false,
+              "legend": "Bookmarking",
+              "properties": {
+                "_isEnabled": {
+                  "type": "boolean",
+                  "required":true,
+                  "default": false,
+                  "title": "Is enabled",
+                  "inputType": {"type": "Boolean", "options": [true, false]},
+                  "validators": [],
+                  "help": "If set to 'true', bookmarking will be turned on. Overrides bookmark setting for the course."
+                }
+              }
+            }
+          }
         },
         "component": {
           "type":"object"
+          "properties":{
+            "_bookmarking": {
+              "type": "object",
+              "required": false,
+              "legend": "Bookmarking",
+              "properties": {
+                "_isEnabled": {
+                  "type": "boolean",
+                  "required":true,
+                  "default": false,
+                  "title": "Is enabled",
+                  "inputType": {"type": "Boolean", "options": [true, false]},
+                  "validators": [],
+                  "help": "If set to 'true', bookmarking will be turned on. Overrides bookmark setting for the course."
+                }
+              }
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Allows to exclude the bookmarked element by checking it's `_bookmarking` property and skipping if disabled. Last accepted (or reset) id will be used.
