### PR TITLE
adds an 'inherit' option to make configuration easier for AAT users

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The following attributes, set within *course.json*, configure the defaults for *
 
 >**_isEnabled** (boolean): Controls whether the bookmarking extension is enabled or not.
 
->**_level** (string): This value determines the type of view to which the learner is returned. Acceptable values are `"page"`, `"block"` or `"component"`. (The `_id` of the most recent view to trigger `inview` is used for routing.)
+>**_level** (string): This value determines which type of Adapt element will be stored as the learner's most current location in the course. Acceptable values are `"page"`, `"block"` or `"component"`. When set to `"block"` or `"component"`, the most recent one to scroll completely into the browser's viewport will be the one that is stored as the learner's current location.
 
 >**_showPrompt** (boolean): Whether to show a prompt asking the user if they'd like to return to where they left off in their last visit or not. If set to `false` the user will be returned to where they left off automatically. The default is `true`.
 
@@ -69,7 +69,7 @@ The defaults set in *course.json* can be overridden for each contentObject of `"
 
 >**_isEnabled** (boolean): Set to `false` to disable bookmarking for the specified content object. 
 
->**_level** (string): This value determines the type of view to which the learner is returned. Acceptable values are `"page"`, `"block"` or `"component"`. (The `_id` of the most recent view to trigger `inview` is used for routing.)  
+>**_level** (string): Allows you to override the **\_level** setting defined in *course.json* with a setting specific to the contentObject. The same values are allowed here, along with an additional setting of `"inherit"` - though this setting is really intended for use by the Adapt Authoring Tool. If building directly in the Framework you can simply not include this property at contentObject level to achieve the same effect as a setting of `"inherit"`.
 
 <div float align=right><a href="#top">Back to Top</a></div>
 
@@ -79,8 +79,8 @@ The defaults set in *course.json* can be overridden for each contentObject of `"
 >**Note:** **Bookmarking** will work without an LMS if run via scorm_test_harness as explained in https://github.com/adaptlearning/adapt-contrib-spoor#client-local-storage--fake-lms--adapt-lms-behaviour-testing. However, this is intended only for development, not for production.
 
 ----------------------------
-**Version number:**  2.1.3   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a> 
-**Framework versions:**  2.0.18+     
+**Version number:**  2.2.0   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a> 
+**Framework versions:**  2.2+   
 **Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-bookmarking/graphs/contributors)    
 **Accessibility support:** WAI AA   
 **RTL support:** yes  

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-bookmarking",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "framework": ">=2.2",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-bookmarking",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new",

--- a/example.json
+++ b/example.json
@@ -14,5 +14,5 @@
 // contentObjects.json - will override course.json for each contentObject - _type "page" only, if set. Set _isEnabled false if no bookmarking on page
 "_bookmarking": {
     "_isEnabled": true,
-    "_level": "page" | "block" | "component"
+    "_level": "inherit" | "page" | "block" | "component"
 }

--- a/js/adapt-contrib-bookmarking.js
+++ b/js/adapt-contrib-bookmarking.js
@@ -168,15 +168,20 @@ define([
                 return;
             }
 
-            this.bookmarkLevel = this.getBookmarkLevel(pageView.model);
-
             this.setLocationID(pageView.model.get('_id'));
+
+            this.bookmarkLevel = this.getBookmarkLevel(pageView.model);
+            if (this.bookmarkLevel === 'page') {
+                return;
+            }
 
             this.watchViewIds = pageView.model.findDescendantModels(this.bookmarkLevel + 's').map(function(desc) {
                 return desc.get('_id');
             });
+
             this.listenTo(Adapt, this.bookmarkLevel + 'View:postRender', this.captureViews);
             this.listenToOnce(Adapt, 'remove', this.releaseViews);
+
             $(window).on('scroll', this._onScroll);
         },
 

--- a/js/adapt-contrib-bookmarking.js
+++ b/js/adapt-contrib-bookmarking.js
@@ -148,22 +148,21 @@ define([
          */
         getBookmarkLevel: function(pageModel) {
             var defaultLevel = Adapt.course.get('_bookmarking')._level || 'component';
-
-            if (pageModel.has('_bookmarking')) {
-                var bookmarkModel = pageModel.get('_bookmarking');
-                if (!bookmarkModel._level || bookmarkModel._level === 'inherit') {
-                    return defaultLevel;
-                }
-
-                return bookmarkModel._level;
-            }
-
-            return defaultLevel;
+            var bookmarkModel = pageModel.get('_bookmarking');
+            var isInherit = !bookmarkModel || !bookmarkModel._level || bookmarkModel._level === 'inherit';
+            return isInherit ? defaultLevel : bookmarkModel._level;
         },
 
+        /**
+         * Sets up bookmarking for the page the learner just navigated to
+         * If bookmarking is disabled for the current page, clear the stored bookmark and return.
+         * Otherwise, bookmark the page then - if necessary - set up to calculate which block or component
+         * should be bookmarked as the learner scrolls up/down the page
+         * @param {Backbone.View} pageView The current page view
+         */
         setupPage: function (pageView) {
-            // is bookmarking disabled at page level?
-            if (pageView.model.has('_bookmarking') && pageView.model.get('_bookmarking')._isEnabled === false) {
+            var pageBookmarkModel = pageView.model.get('_bookmarking');
+            if (pageBookmarkModel && pageBookmarkModel._isEnabled === false) {
                 this.resetLocationID();
                 return;
             }

--- a/properties.schema
+++ b/properties.schema
@@ -31,10 +31,21 @@
                 "_level": {
                   "type": "string",
                   "required": true,
-                  "enum": ["page", "block", "component"],
+                  "enum": [
+                    "page",
+                    "block",
+                    "component"
+                  ],
                   "default": "page",
                   "title": "Level",
-                  "inputType": {"type": "Select", "options":["page", "block", "component"]},
+                  "inputType": {
+                    "type": "Select",
+                    "options": [
+                      "page",
+                      "block",
+                      "component"
+                    ]
+                  },
                   "validators": ["required"],
                   "help": "Allows you to set whether Bookmarking is done at page, block or component level."
                 },
@@ -111,12 +122,25 @@
                 "_level": {
                   "type": "string",
                   "required": true,
-                  "enum": ["page", "block", "component"],
-                  "default": "page",
+                  "enum": [
+                    "inherit",
+                    "page",
+                    "block",
+                    "component"
+                  ],
+                  "default": "inherit",
                   "title": "Level",
-                  "inputType": {"type": "Select", "options":["page", "block", "component"]},
+                  "inputType": {
+                    "type": "Select",
+                    "options": [
+                      "inherit",
+                      "page",
+                      "block",
+                      "component"
+                    ]
+                  },
                   "validators": ["required"],
-                  "help": "Allows you to set whether Bookmarking is done at page, block or component level for this page of the course."
+                  "help": "Whether you want to inherit the 'Level' setting from Project settings or override it for this page of the course."
                 }
               }
             }


### PR DESCRIPTION
resolves https://github.com/adaptlearning/adapt_framework/issues/2401

Also now handles setting the 'level' to a default value (`"component"`) if not defined anywhere