### PR TITLE
issue/2763 Updated to use Adapt.navigateToElement (v5.7.0)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-contrib-bookmarking",
   "version": "3.0.0",
-  "framework": ">=5",
+  "framework": ">=5.5",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-bookmarking",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new",
   "extension" : "bookmarking",

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-contrib-bookmarking",
   "version": "3.0.0",
-  "framework": ">=5.5",
+  "framework": ">=5.6",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-bookmarking",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new",
   "extension" : "bookmarking",

--- a/js/adapt-contrib-bookmarking.js
+++ b/js/adapt-contrib-bookmarking.js
@@ -108,9 +108,9 @@ define([
     },
 
     navigateToPrevious: function() {
-      _.defer(function() {
+      _.defer(async function() {
         var isSinglePage = Adapt.contentObjects.models.length == 1;
-        Backbone.history.navigate('#/id/' + this.restoredLocationID, {trigger: true, replace: isSinglePage});
+        await Adapt.navigateToElement('.' + this.restoredLocationID, { trigger: true, replace: isSinglePage, duration: 400 });
       }.bind(this));
 
       this.stopListening(Adapt, 'bookmarking:cancel');


### PR DESCRIPTION
fixes [#2763](https://github.com/adaptlearning/adapt_framework/issues/2763)

Part of [#2760](https://github.com/adaptlearning/adapt_framework/issues/2760)

#### Changed
* Updated to use Adapt.navigateToElement to ensure views are rendered before returning the user to them
* Bumped framework dependency to v5.6

Requires [#2761](https://github.com/adaptlearning/adapt_framework/pull/2761)