### PR TITLE
issue/44 Filter trickle buttons, support ChildView API

### DIFF
--- a/js/adapt-contrib-bookmarking.js
+++ b/js/adapt-contrib-bookmarking.js
@@ -195,7 +195,7 @@ class Bookmarking extends Backbone.Controller {
   checkLocation() {
     const currentModel = Adapt.location._currentModel;
     if (!currentModel) return;
-    const possibleViewIds = currentModel.findDescendantModels(this.bookmarkLevel + 's')
+    const possibleViewIds = currentModel.findDescendantModels(this.bookmarkLevel)
       .filter(desc => desc.get('_isTrackable') !== false) // Filter trickle buttons
       .map(desc => desc.get('_id'));
 

--- a/js/adapt-contrib-bookmarking.js
+++ b/js/adapt-contrib-bookmarking.js
@@ -22,10 +22,11 @@ class Bookmarking extends Backbone.Controller {
   }
 
   setupEventListeners() {
-    this._onScroll = _.debounce(this.checkLocation.bind(this), 1000);
+    this._onScroll = _.debounce(this.checkLocation.bind(this), 250);
     this.listenTo(Adapt, {
       'menuView:ready': this.setupMenu,
-      'pageView:preRender': this.setupPage
+      'pageView:preRender': this.setupPage,
+      'view:childAdded': this.checkLocation
     });
   }
 
@@ -194,7 +195,9 @@ class Bookmarking extends Backbone.Controller {
   checkLocation() {
     const currentModel = Adapt.location._currentModel;
     if (!currentModel) return;
-    const possibleViewIds = currentModel.findDescendantModels(this.bookmarkLevel + 's').map(desc => desc.get('_id'));
+    const possibleViewIds = currentModel.findDescendantModels(this.bookmarkLevel + 's')
+      .filter(desc => desc.get('_isTrackable') !== false) // Filter trickle buttons
+      .map(desc => desc.get('_id'));
 
     let highestOnscreen = 0;
     let highestOnscreenLocation = '';


### PR DESCRIPTION
fixes #44 

### Fixed
* Stopped bookmarking trickle buttons by filtering `_isTrackable: false` from bookmarkable models
* Ensured childView additions cause bookmarking to check
* Reduced scroll debouce to make bookmarking more responsive
* Pluralisation error
![image](https://user-images.githubusercontent.com/7974663/132666755-7a08d60c-3226-4a92-8fff-7b3a3b1532e4.png)
