### PR TITLE
New: Furthest location & button features (fixes: #63)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ Controls whether the bookmarking extension is enabled or not.
 ##### \_level (string):
 This value determines which type of Adapt element will be stored as the learner's most current location in the course. Acceptable values are `"page"`, `"block"` or `"component"`. When set to `"block"` or `"component"`, the most recent one to scroll completely into the browser's viewport will be the one that is stored as the learner's current location. The default value is `"component"`.
 
+##### \_location (string):
+This value determines where learners will be taken to upon resume. `"previous"` will take leaners back to their last visited location. `"furthest"` will take learners to their furthest incomplete location. The furthest option will pair best in a course experience with linear progression.
+
 ##### \_showPrompt (boolean):
 Whether to show a prompt asking the user if they'd like to return to where they left off in their last visit or not. If set to `false` the user will be returned to where they left off automatically. The default is `true`.
 

--- a/README.md
+++ b/README.md
@@ -95,11 +95,11 @@ Allows you to override the **\_level** setting defined in *course.json* with a s
 <div float align=right><a href="#top">Back to Top</a></div>
 
 ## Unique Element Tags
-The bookmarking plug-in allows you to place a button in any compiled json field (e.g. attribute, displayTitle, body, instruction, etc). This button will route learners to their furtest point of progress. Additionally, you may use attributes to alter the default labels in course.json.
+The bookmarking plug-in allows you to place a button in any compiled json field (e.g. attribute, displayTitle, body, instruction, etc). This button will route learners to their furthest point of progress. Additionally, you may use attributes to alter the default labels in course.json.
 ```json
 {
   "body": "<bookmarking />",
-  "body": "<bookmarking label='Resume course' aria-label='Navigate to your furthest point of progress.' />",
+  "body": "<bookmarking label='Resume' aria-label='Navigate to your furthest point of progress.' />",
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ The bookmarking plug-in allows you to place a button in any compiled json field 
 {
   "body": "<bookmarking label='Resume' aria-label='Navigate to your furthest point of progress.' />",
 }
+{
+  "instruction": "<bookmarking aria-label='Navigate to your furthest point of progress.'>Resume</bookmarking>",
+}
 ```
 
 <div float align=right><a href="#top">Back to Top</a></div>

--- a/README.md
+++ b/README.md
@@ -91,13 +91,15 @@ Allows you to override the **\_level** setting defined in *course.json* with a s
 
 <div float align=right><a href="#top">Back to Top</a></div>
 
-## Custom Element Tags
+## Unique Element Tags
 The bookmarking plug-in allows you to place a button in any compiled json field (e.g. attribute, displayTitle, body, instruction, etc). This button will route learners to their furtest point of progress.
 ```json
 {
   "body": "<bookmarking label='Resume' aria-label='Navigate to your furthest point of progress.' />",
 }
 ```
+
+<div float align=right><a href="#top">Back to Top</a></div>
 
 ## Limitations
 **Bookmarking** only works if the [spoor plugin](https://github.com/adaptlearning/adapt-contrib-spoor) is enabled and the course is being launched from an <abbr title="Learning Management System">LMS</abbr> OR the xAPI plugin is enabled and the course is connected to an <abbr title="Learning Record Store">LRS</abbr>.

--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ Allows you to override the **\_level** setting defined in *course.json* with a s
 
 <div float align=right><a href="#top">Back to Top</a></div>
 
+## Custom Element Tags
+The bookmarking plug-in allows you to place a button in any compiled json field (e.g. attribute, displayTitle, body, instruction, etc). This button will route learners to their furtest point of progress.
+```json
+{
+  "body": "<bookmarking label='Resume' aria-label='Navigate to your furthest point of progress.' />",
+}
+```
+
 ## Limitations
 **Bookmarking** only works if the [spoor plugin](https://github.com/adaptlearning/adapt-contrib-spoor) is enabled and the course is being launched from an <abbr title="Learning Management System">LMS</abbr> OR the xAPI plugin is enabled and the course is connected to an <abbr title="Learning Record Store">LRS</abbr>.
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Allows you to override the **\_level** setting defined in *course.json* with a s
 <div float align=right><a href="#top">Back to Top</a></div>
 
 ## Unique Element Tags
-The bookmarking plug-in allows you to place a button in any compiled json field (e.g. attribute, displayTitle, body, instruction, etc). This button will route learners to their furtest point of progress.
+The bookmarking plug-in allows you to place a button in any compiled json field (e.g. attribute, displayTitle, body, instruction, etc). This button will route learners to their furtest point of progress. Attributes allowed within the tag include a `label` & `ariaLabel` to be set on each button.
 ```json
 {
   "body": "<bookmarking label='Resume' aria-label='Navigate to your furthest point of progress.' />",

--- a/README.md
+++ b/README.md
@@ -95,13 +95,11 @@ Allows you to override the **\_level** setting defined in *course.json* with a s
 <div float align=right><a href="#top">Back to Top</a></div>
 
 ## Unique Element Tags
-The bookmarking plug-in allows you to place a button in any compiled json field (e.g. attribute, displayTitle, body, instruction, etc). This button will route learners to their furtest point of progress. Attributes allowed within the tag include a `label` & `ariaLabel` to be set on each button.
+The bookmarking plug-in allows you to place a button in any compiled json field (e.g. attribute, displayTitle, body, instruction, etc). This button will route learners to their furtest point of progress. Additionally, you may use attributes to alter the default labels in course.json.
 ```json
 {
-  "body": "<bookmarking label='Resume' aria-label='Navigate to your furthest point of progress.' />",
-}
-{
-  "instruction": "<bookmarking aria-label='Navigate to your furthest point of progress.'>Resume</bookmarking>",
+  "body": "<bookmarking />",
+  "body": "<bookmarking label='Resume course' aria-label='Navigate to your furthest point of progress.' />",
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -98,11 +98,11 @@ Allows you to override the **\_level** setting defined in *course.json* with a s
 <div float align=right><a href="#top">Back to Top</a></div>
 
 ## Unique Element Tags
-The bookmarking plug-in allows you to place a button in any compiled json field (e.g. attribute, displayTitle, body, instruction, etc). This button will route learners to their furthest point of progress. Additionally, you may use attributes to alter the default labels in course.json.
+The bookmarking plug-in allows you to place a button in any compiled json field (e.g. attribute, displayTitle, body, instruction, etc). This button will route learners to their previous or furthest location. Additionally, you may use attributes to alter the default labels in course.json.
 ```json
 {
   "body": "<bookmarking />",
-  "body": "<bookmarking label='Resume' aria-label='Navigate to your furthest point of progress.' />",
+  "body": "<bookmarking label='Resume' aria-label='Navigate to your furthest point of progress.' location='furthest' />",
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ This value determines where learners will be taken to upon resume. `"previous"` 
 ##### \_showPrompt (boolean):
 Whether to show a prompt asking the user if they'd like to return to where they left off in their last visit or not. If set to `false` the user will be returned to where they left off automatically. The default is `true`.
 
+##### \_autoRestore (boolean):
+Controls whether the Bookmarking will automatically restore if the prompt is disabled. If not enabled, the user will be not be automatically returned to their bookmarked position. The default is `true`.
+
 ##### title (string):
 Text that appears as the header of the prompt.
 

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-contrib-bookmarking",
   "version": "4.2.0",
-  "framework": ">=5.19.1",
+  "framework": ">=5.31.11",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-bookmarking",
   "bugs": "https://github.com/adaptlearning/adapt-contrib-bookmarking/issues",
   "extension": "bookmarking",

--- a/example.json
+++ b/example.json
@@ -6,6 +6,7 @@
         "_comment": "_location can be set to previous or furthest",
         "_location": "previous",
         "_showPrompt": true,
+        "_autoRestore": true,
         "title": "Bookmarking",
         "body": "Would you like to continue where you left off?",
         "_buttons": {

--- a/example.json
+++ b/example.json
@@ -23,3 +23,4 @@
 
     // Unique element tag placement. Place a button in any compiled json field (e.g. attribute, displayTitle, body, instruction, etc)
     "body": "<bookmarking label='Resume' aria-label='Navigate to your furthest point of progress.' />",
+    "body": "<bookmarking aria-label='Navigate to your furthest point of progress.'>Resume</bookmarking>",

--- a/example.json
+++ b/example.json
@@ -22,5 +22,6 @@
     }
 
     // Unique element tag placement. Place a button in any compiled json field (e.g. attribute, displayTitle, body, instruction, etc)
-    "body": "<bookmarking label='Resume' aria-label='Navigate to your furthest point of progress.' />",
-    "body": "<bookmarking aria-label='Navigate to your furthest point of progress.'>Resume</bookmarking>",
+    "body": "<bookmarking />",
+    // Attribute labels that override course.json
+    "body": "<bookmarking label='Resume course' aria-label='Navigate to your furthest point of progress.' />",

--- a/example.json
+++ b/example.json
@@ -22,4 +22,4 @@
     }
 
     // Unique element tag placement. Place a button in any compiled json field (e.g. attribute, displayTitle, body, instruction, etc)
-    "body": "Welcome to the demonstration build for version 5 of the Adapt framework.<br><br><bookmarking label='Resume' aria-label='Navigate to your furthest point of progress.' />",
+    "body": "<bookmarking label='Resume' aria-label='Navigate to your furthest point of progress.' />",

--- a/example.json
+++ b/example.json
@@ -24,4 +24,4 @@
     // Unique element tag placement. Place a button in any compiled json field (e.g. attribute, displayTitle, body, instruction, etc)
     "body": "<bookmarking />",
     // Attribute labels that override course.json
-    "body": "<bookmarking label='Resume course' aria-label='Navigate to your furthest point of progress.' />",
+    "body": "<bookmarking location='furthest' label='Resume course' aria-label='Navigate to your furthest point of progress.' />",

--- a/example.json
+++ b/example.json
@@ -24,4 +24,5 @@
     // Unique element tag placement. Place a button in any compiled json field (e.g. attribute, displayTitle, body, instruction, etc)
     "body": "<bookmarking />",
     // Attribute labels that override course.json
-    "body": "<bookmarking location='furthest' label='Resume course' aria-label='Navigate to your furthest point of progress.' />",
+    "body": "<bookmarking location='previous' label='Resume' aria-label='Continue where you left off.' />",
+    "body": "<bookmarking location='furthest' label='Continue' aria-label='Navigate to your furthest point of progress.' />",

--- a/example.json
+++ b/example.json
@@ -3,6 +3,8 @@
         "_isEnabled": true,
         "_comment": "_level can be set to page, block, or component",
         "_level": "page",
+        "_comment": "_location can be set to previous or furthest",
+        "_location": "previous",
         "_showPrompt": true,
         "title": "Bookmarking",
         "body": "Would you like to continue where you left off?",
@@ -18,3 +20,6 @@
         "_comment": "_level can be set to inherit, page, block, or component",
         "_level": "inherit"
     }
+
+    // Unique element tag placement. Place a button in any compiled json field (e.g. attribute, displayTitle, body, instruction, etc)
+    "body": "Welcome to the demonstration build for version 5 of the Adapt framework.<br><br><bookmarking label='Resume' aria-label='Navigate to your furthest point of progress.' />",

--- a/js/BookmarkingModel.js
+++ b/js/BookmarkingModel.js
@@ -1,3 +1,10 @@
 export default class BookmarkingModel extends Backbone.Model {
 
+  defaults () {
+    return {
+      label: '',
+      ariaLabel: ''
+    };
+  }
+
 }

--- a/js/BookmarkingModel.js
+++ b/js/BookmarkingModel.js
@@ -1,0 +1,3 @@
+export default class BookmarkingModel extends Backbone.Model {
+
+}

--- a/js/BookmarkingModel.js
+++ b/js/BookmarkingModel.js
@@ -3,7 +3,8 @@ export default class BookmarkingModel extends Backbone.Model {
   defaults () {
     return {
       label: '',
-      ariaLabel: ''
+      ariaLabel: '',
+      _location: 'previous'
     };
   }
 

--- a/js/BookmarkingView.js
+++ b/js/BookmarkingView.js
@@ -1,0 +1,47 @@
+import Adapt from 'core/js/adapt';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { templates, classes } from 'core/js/reactHelpers';
+
+export default class BookmarkingView extends Backbone.View {
+
+  get config() {
+    return Adapt.course.get('_bookmarking');
+  }
+
+  className() {
+    return classes([
+      'bookmarking-resume'
+    ]);
+  }
+
+  events() {
+    return {
+      'click .js-bookmarking-resume-button': 'onResumeClicked'
+    };
+  }
+
+  initialize() {
+    this._classSet = new Set(_.result(this, 'className').trim().split(/\s+/));
+    this.render();
+  }
+
+  render() {
+    const Template = templates.bookmarkingResume;
+    this.updateViewProperties();
+    ReactDOM.render(<Template {...this.model.toJSON()} />, this.el);
+  }
+
+  updateViewProperties() {
+    const classesToAdd = _.result(this, 'className').trim().split(/\s+/);
+    classesToAdd.forEach(i => this._classSet.add(i));
+    const classesToRemove = [ ...this._classSet ].filter(i => !classesToAdd.includes(i));
+    classesToRemove.forEach(i => this._classSet.delete(i));
+    this._setAttributes({ ..._.result(this, 'attributes'), id: _.result(this, 'id') });
+    this.$el.removeClass(classesToRemove).addClass(classesToAdd);
+  }
+
+  onResumeClicked() {
+    Adapt.trigger('bookmarking:resume');
+  }
+}

--- a/js/BookmarkingView.js
+++ b/js/BookmarkingView.js
@@ -42,6 +42,6 @@ export default class BookmarkingView extends Backbone.View {
   }
 
   onResumeClicked() {
-    Adapt.trigger('bookmarking:resume');
+    Adapt.trigger('bookmarking:resume', this.model.get('_location'));
   }
 }

--- a/js/adapt-contrib-bookmarking.js
+++ b/js/adapt-contrib-bookmarking.js
@@ -9,7 +9,7 @@ import BookmarkingModel from './BookmarkingModel';
 import BookmarkingView from './BookmarkingView';
 import documentModifications from 'core/js/DOMElementModifications';
 
-// Allow self-closing <bookmarking /> in any compiled json attribute, displayTitle, body, instruction, etc
+// Allow self-closing <bookmarking-resume /> in any compiled json attribute, displayTitle, body, instruction, etc
 const selfClosingCustomTag = /<((bookmarking)[^>]*)\/>/gi;
 const o2 = Handlebars.compile;
 Handlebars.compile = html => o2(html.replace(selfClosingCustomTag, '<$1></$2>'));
@@ -21,6 +21,10 @@ class Bookmarking extends Backbone.Controller {
     this.restoredLocationID = null;
     this.currentLocationID = null;
     this.listenToOnce(Adapt, 'router:location', this.onAdaptInitialize);
+  }
+
+  get globals() {
+    return Adapt.course.get('_globals');
   }
 
   get config() {
@@ -61,15 +65,17 @@ class Bookmarking extends Backbone.Controller {
 
   onAdd(event) {
     if (!this.isEnabled) return;
-    const $target = $(event.target);
+    const resumeLabel = this.globals._accessibility.bookmarkingResumeText;
+    const resumeAria = this.globals._accessibility._ariaLabels.resume;
+    console.log(resumeLabel, resumeAria);
+    const $target = $(event.target);//
     const model = new BookmarkingModel({
-      label: $target.attr('label') || $target.html() || null,
-      ariaLabel: $target.attr('aria-label') || null
+      label: $target.attr('label') || resumeLabel || $target.html() || null,
+      ariaLabel: $target.attr('aria-label') || resumeAria || null
     });
     const view = new BookmarkingView({
       model
     });
-    view.el._view = view;
     $target.replaceWith(view.$el);
   }
 
@@ -140,7 +146,7 @@ class Bookmarking extends Backbone.Controller {
   }
 
   navigateTo() {
-    const locationConfig = this.config._location || 'previous';
+    const locationConfig = this.config._location;
     switch (locationConfig) {
       case 'previous': {
         this.navigateToPrevious();

--- a/js/adapt-contrib-bookmarking.js
+++ b/js/adapt-contrib-bookmarking.js
@@ -140,7 +140,7 @@ class Bookmarking extends Backbone.Controller {
   }
 
   navigateTo() {
-    const locationConfig = this.config._location;
+    const locationConfig = this.config._location || 'previous';
     switch (locationConfig) {
       case 'previous': {
         this.navigateToPrevious();

--- a/js/adapt-contrib-bookmarking.js
+++ b/js/adapt-contrib-bookmarking.js
@@ -67,7 +67,7 @@ class Bookmarking extends Backbone.Controller {
     if (!this.isEnabled) return;
     const resumeLabel = this.globals._extensions._bookmarking.resumeButtonLabel;
     const resumeAria = this.globals._extensions._bookmarking.resumeButtonAriaLabel;
-    const $target = $(event.target);//
+    const $target = $(event.target);
     const model = new BookmarkingModel({
       label: $target.attr('label') || resumeLabel || $target.html() || null,
       ariaLabel: $target.attr('aria-label') || resumeAria || null

--- a/js/adapt-contrib-bookmarking.js
+++ b/js/adapt-contrib-bookmarking.js
@@ -9,7 +9,7 @@ import BookmarkingModel from './BookmarkingModel';
 import BookmarkingView from './BookmarkingView';
 import documentModifications from 'core/js/DOMElementModifications';
 
-// Allow self-closing <bookmarking-resume /> in any compiled json attribute, displayTitle, body, instruction, etc
+// Allow self-closing <bookmarking /> in any compiled json attribute, displayTitle, body, instruction, etc
 const selfClosingCustomTag = /<((bookmarking)[^>]*)\/>/gi;
 const o2 = Handlebars.compile;
 Handlebars.compile = html => o2(html.replace(selfClosingCustomTag, '<$1></$2>'));

--- a/js/adapt-contrib-bookmarking.js
+++ b/js/adapt-contrib-bookmarking.js
@@ -41,7 +41,7 @@ class Bookmarking extends Backbone.Controller {
 
   getLocationId(location = this.location) {
     const id = (location === 'furthest')
-      ? this.furthestIncompleteModel.get('_id')
+      ? this.furthestIncompleteModel?.get?.('_id')
       : this.restoredLocationID;
     return id;
   }
@@ -173,6 +173,7 @@ class Bookmarking extends Backbone.Controller {
 
   navigateTo(location = this.location) {
     const id = this.getLocationId(location);
+    if (['', undefined, 'current'].includes(id)) return;
     _.defer(async () => {
       try {
         const isSinglePage = (Adapt.contentObjects.models.length === 1);

--- a/js/adapt-contrib-bookmarking.js
+++ b/js/adapt-contrib-bookmarking.js
@@ -47,7 +47,6 @@ class Bookmarking extends Backbone.Controller {
     const bookmarkLevel = Adapt.course.get('_bookmarking')._level || 'component';
     const getIncompleteModels = Adapt.course.findDescendantModels(bookmarkLevel, { where: { _isComplete: false, _isAvailable: true, _isOptional: false } });
     const furthestIncompleteModel = getIncompleteModels.at(0);
-    console.log(Views.currentBlockView.$el);
     return furthestIncompleteModel;
   }
 

--- a/js/adapt-contrib-bookmarking.js
+++ b/js/adapt-contrib-bookmarking.js
@@ -55,7 +55,7 @@ class Bookmarking extends Backbone.Controller {
       'pageView:preRender': this.setupPage,
       'view:childAdded': this.onChildViewAdded,
       'view:preRemove': this.onChildViewPreRemove,
-      'bookmarking:resume': this.navigateToFurthest
+      'bookmarking:resume': this.navigateTo
     });
     this.listenTo(documentModifications, {
       'added:bookmarking': this.onAdd,

--- a/js/adapt-contrib-bookmarking.js
+++ b/js/adapt-contrib-bookmarking.js
@@ -148,8 +148,7 @@ class Bookmarking extends Backbone.Controller {
   }
 
   showPrompt() {
-    const courseBookmarkModel = this.config;
-    const buttons = courseBookmarkModel._buttons || { yes: 'Yes', no: 'No' };
+    const buttons = this.config._buttons || { yes: 'Yes', no: 'No' };
     this.listenToOnce(Adapt, {
       'bookmarking:continue': this.navigateTo,
       'bookmarking:cancel': this.navigateCancel
@@ -157,8 +156,8 @@ class Bookmarking extends Backbone.Controller {
     notify.prompt({
       _classes: 'is-bookmarking',
       _showIcon: true,
-      title: courseBookmarkModel.title,
-      body: courseBookmarkModel.body,
+      title: this.config.title,
+      body: this.config.body,
       _prompts: [
         {
           promptText: buttons.yes || 'Yes',

--- a/js/adapt-contrib-bookmarking.js
+++ b/js/adapt-contrib-bookmarking.js
@@ -47,7 +47,7 @@ class Bookmarking extends Backbone.Controller {
   }
 
   get furthestIncompleteModel() {
-    const bookmarkLevel = Adapt.course.get('_bookmarking')._level || 'component';
+    const bookmarkLevel = this.config._level || 'component';
     const getIncompleteModels = Adapt.course.findDescendantModels(bookmarkLevel, { where: { _isComplete: false, _isAvailable: true, _isOptional: false } });
     const furthestIncompleteModel = getIncompleteModels.at(0);
     return furthestIncompleteModel;
@@ -60,7 +60,7 @@ class Bookmarking extends Backbone.Controller {
   }
 
   checkCourseIsEnabled() {
-    const courseBookmarkModel = Adapt.course.get('_bookmarking');
+    const courseBookmarkModel = this.config;
     if (!courseBookmarkModel || !courseBookmarkModel._isEnabled) return false;
     return true;
   }
@@ -121,8 +121,9 @@ class Bookmarking extends Backbone.Controller {
   restoreLocation() {
     this.stopListening(Adapt, 'pageView:ready menuView:ready', this.restoreLocation);
     _.delay(() => {
+      if (this.config._autoRestore === false) return;
       if (this.isAlreadyOnScreen(this.restoredLocationID)) return;
-      if (Adapt.course.get('_bookmarking')._showPrompt === false) {
+      if (this.config._showPrompt === false) {
         this.navigateTo();
         return;
       }
@@ -147,7 +148,7 @@ class Bookmarking extends Backbone.Controller {
   }
 
   showPrompt() {
-    const courseBookmarkModel = Adapt.course.get('_bookmarking');
+    const courseBookmarkModel = this.config;
     const buttons = courseBookmarkModel._buttons || { yes: 'Yes', no: 'No' };
     this.listenToOnce(Adapt, {
       'bookmarking:continue': this.navigateTo,
@@ -213,7 +214,7 @@ class Bookmarking extends Backbone.Controller {
    * @return {String} Either 'page', 'block', or 'component' - with 'component' being the default
    */
   getBookmarkLevel(pageModel) {
-    const defaultLevel = Adapt.course.get('_bookmarking')._level || 'component';
+    const defaultLevel = this.config._level || 'component';
     const bookmarkModel = pageModel.get('_bookmarking');
     const isInherit = !bookmarkModel || !bookmarkModel._level || bookmarkModel._level === 'inherit';
     return isInherit ? defaultLevel : bookmarkModel._level;

--- a/js/adapt-contrib-bookmarking.js
+++ b/js/adapt-contrib-bookmarking.js
@@ -63,7 +63,7 @@ class Bookmarking extends Backbone.Controller {
     if (!this.isEnabled) return;
     const $target = $(event.target);
     const model = new BookmarkingModel({
-      label: $target.attr('label') || null,
+      label: $target.attr('label') || $target.html() || null,
       ariaLabel: $target.attr('aria-label') || null
     });
     const view = new BookmarkingView({

--- a/js/adapt-contrib-bookmarking.js
+++ b/js/adapt-contrib-bookmarking.js
@@ -67,7 +67,6 @@ class Bookmarking extends Backbone.Controller {
     if (!this.isEnabled) return;
     const resumeLabel = this.globals._extensions._bookmarking.resumeButtonLabel;
     const resumeAria = this.globals._extensions._bookmarking.resumeButtonAriaLabel;
-    console.log(resumeLabel, resumeAria);
     const $target = $(event.target);//
     const model = new BookmarkingModel({
       label: $target.attr('label') || resumeLabel || $target.html() || null,

--- a/js/adapt-contrib-bookmarking.js
+++ b/js/adapt-contrib-bookmarking.js
@@ -47,6 +47,7 @@ class Bookmarking extends Backbone.Controller {
     const bookmarkLevel = Adapt.course.get('_bookmarking')._level || 'component';
     const getIncompleteModels = Adapt.course.findDescendantModels(bookmarkLevel, { where: { _isComplete: false, _isAvailable: true, _isOptional: false } });
     const furthestIncompleteModel = getIncompleteModels.at(0);
+    console.log(Views.currentBlockView.$el);
     return furthestIncompleteModel;
   }
 
@@ -80,13 +81,16 @@ class Bookmarking extends Backbone.Controller {
 
   onAdd(event) {
     if (!this.isEnabled) return;
-    if (this.config._location !== 'furthest' || !this.furthestIncompleteModel) return;
     const resumeLabel = this.globals._extensions._bookmarking.resumeButtonText;
     const resumeAria = this.globals._extensions._bookmarking.resumeButtonAriaLabel;
     const $target = $(event.target);
+    const isDisabled = (this.navigateToId === '' || this.navigateToId === undefined || this.navigateToId === 'current')
+      ? 'is-disabled'
+      : '';
     const model = new BookmarkingModel({
       label: $target.attr('label') || resumeLabel || $target.html() || null,
-      ariaLabel: $target.attr('aria-label') || resumeAria || null
+      ariaLabel: $target.attr('aria-label') || resumeAria || null,
+      isDisabled
     });
     const view = new BookmarkingView({
       model

--- a/js/adapt-contrib-bookmarking.js
+++ b/js/adapt-contrib-bookmarking.js
@@ -65,8 +65,8 @@ class Bookmarking extends Backbone.Controller {
 
   onAdd(event) {
     if (!this.isEnabled) return;
-    const resumeLabel = this.globals._accessibility.bookmarkingResumeText;
-    const resumeAria = this.globals._accessibility._ariaLabels.resume;
+    const resumeLabel = this.globals._extensions._bookmarking.resumeButtonLabel;
+    const resumeAria = this.globals._extensions._bookmarking.resumeButtonAriaLabel;
     console.log(resumeLabel, resumeAria);
     const $target = $(event.target);//
     const model = new BookmarkingModel({

--- a/js/adapt-contrib-bookmarking.js
+++ b/js/adapt-contrib-bookmarking.js
@@ -262,7 +262,7 @@ class Bookmarking extends Backbone.Controller {
     if (highestOnscreenLocation) this.setLocationID(highestOnscreenLocation);
   }
 
-  checkFurthestIncompleteModel() {
+  get furthestIncompleteModel() {
     const bookmarkLevel = Adapt.course.get('_bookmarking')._level || 'component';
     const getIncompleteModels = Adapt.course.findDescendantModels(bookmarkLevel, { where: { _isComplete: false, _isAvailable: true, _isOptional: false } });
     const furthestIncompleteModel = getIncompleteModels.at(0);

--- a/js/adapt-contrib-bookmarking.js
+++ b/js/adapt-contrib-bookmarking.js
@@ -37,15 +37,10 @@ class Bookmarking extends Backbone.Controller {
 
   get navigateToId() {
     const locationConfig = this.config._location || 'previous';
-    if (locationConfig === 'furthest') {
-      if (typeof this.furthestIncompleteModel === 'undefined') {
-        return this.restoredLocationID;
-      } else {
-        return this.furthestIncompleteModel.get('_id');
-      }
-    } else {
-      return this.restoredLocationID;
-    }
+    const navigateToId = (locationConfig === 'furthest')
+      ? this.furthestIncompleteModel.get('_id')
+      : this.restoredLocationID;
+    return navigateToId;
   }
 
   get furthestIncompleteModel() {
@@ -84,7 +79,8 @@ class Bookmarking extends Backbone.Controller {
   }
 
   onAdd(event) {
-    if (!this.isEnabled || !this.furthestIncompleteModel) return;
+    if (!this.isEnabled) return;
+    if (this.config._location !== 'furthest' || !this.furthestIncompleteModel) return;
     const resumeLabel = this.globals._extensions._bookmarking.resumeButtonText;
     const resumeAria = this.globals._extensions._bookmarking.resumeButtonAriaLabel;
     const $target = $(event.target);

--- a/js/adapt-contrib-bookmarking.js
+++ b/js/adapt-contrib-bookmarking.js
@@ -166,8 +166,8 @@ class Bookmarking extends Backbone.Controller {
   }
 
   navigateToFurthest() {
-    const furthestModel = this.checkFurthestIncompleteModel();
-    const furthestId = furthestModel.attributes._id;
+    const furthestModel = this.furthestIncompleteModel;
+    const furthestId = furthestModel.get('_id');
 
     _.defer(async () => {
       try {

--- a/js/adapt-contrib-bookmarking.js
+++ b/js/adapt-contrib-bookmarking.js
@@ -37,10 +37,15 @@ class Bookmarking extends Backbone.Controller {
 
   get navigateToId() {
     const locationConfig = this.config._location || 'previous';
-    const navigateToId = (locationConfig === 'furthest')
-      ? this.furthestIncompleteModel.get('_id')
-      : this.restoredLocationID;
-    return navigateToId;
+    if (locationConfig === 'furthest') {
+      if (typeof this.furthestIncompleteModel === 'undefined') {
+        return this.restoredLocationID;
+      } else {
+        return this.furthestIncompleteModel.get('_id');
+      }
+    } else {
+      return this.restoredLocationID;
+    }
   }
 
   get furthestIncompleteModel() {
@@ -79,11 +84,10 @@ class Bookmarking extends Backbone.Controller {
   }
 
   onAdd(event) {
-    if (!this.isEnabled) return;
+    if (!this.isEnabled || !this.furthestIncompleteModel) return;
     const resumeLabel = this.globals._extensions._bookmarking.resumeButtonText;
     const resumeAria = this.globals._extensions._bookmarking.resumeButtonAriaLabel;
-    console.log(resumeLabel, resumeAria);
-    const $target = $(event.target);//
+    const $target = $(event.target);
     const model = new BookmarkingModel({
       label: $target.attr('label') || resumeLabel || $target.html() || null,
       ariaLabel: $target.attr('aria-label') || resumeAria || null

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-contrib-bookmarking",
   "version": "4.2.0",
-  "framework": ">=5.19.1",
+  "framework": ">=5.31.11",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-bookmarking",
   "bugs": "https://github.com/adaptlearning/adapt-contrib-bookmarking/issues",
   "extension": "bookmarking",

--- a/properties.schema
+++ b/properties.schema
@@ -11,7 +11,6 @@
       "inputType": "Text",
       "validators": [],
       "translatable": true,
-      "help": "Label for ubiquitous resume button."
     },
     "resumeButtonAriaLabel": {
       "type": "string",

--- a/properties.schema
+++ b/properties.schema
@@ -11,7 +11,7 @@
       "inputType": "Text",
       "validators": [],
       "translatable": true,
-      "help": "Unique element tag label for resume button."
+      "help": "Label for ubiquitous resume button."
     },
     "resumeButtonAriaLabel": {
       "type": "string",
@@ -20,7 +20,7 @@
       "inputType": "Text",
       "validators": [],
       "translatable": true,
-      "help": "Unique element tag ARIA label for resume button."
+      "help": "ARIA label for ubiquitous resume button."
     }
   },
   "properties": {

--- a/properties.schema
+++ b/properties.schema
@@ -97,6 +97,15 @@
                   "validators": [],
                   "help": "Controls whether the Bookmarking prompt is enabled or disabled. If not enabled, the user will be returned to their bookmarked position automatically."
                 },
+                "_autoRestore": {
+                  "type": "boolean",
+                  "required": true,
+                  "default": true,
+                  "title": "Auto restore",
+                  "inputType": "Checkbox",
+                  "validators": [],
+                  "help": "Controls whether the Bookmarking will automatically restore if the prompt is disabled. If not enabled, the user will be not be automatically returned to their bookmarked position."
+                },
                 "title": {
                   "type": "string",
                   "default": "Bookmarking",

--- a/properties.schema
+++ b/properties.schema
@@ -4,21 +4,23 @@
   "id": "http://jsonschema.net",
   "required": false,
   "globals": {
-    "resumeButtonLabel": {
+    "resumeButtonText": {
       "type": "string",
       "required": true,
+      "title": "Resume button text",
       "default": "Resume",
       "inputType": "Text",
       "validators": [],
-      "translatable": true,
+      "translatable": true
     },
     "resumeButtonAriaLabel": {
       "type": "string",
       "required": true,
+      "title": "Resume ARIA label",
       "default": "Navigate to your furthest point of progress.",
       "inputType": "Text",
       "validators": [],
-      "translatable": true,
+      "translatable": true
     }
   },
   "properties": {

--- a/properties.schema
+++ b/properties.schema
@@ -19,7 +19,6 @@
       "inputType": "Text",
       "validators": [],
       "translatable": true,
-      "help": "ARIA label for ubiquitous resume button."
     }
   },
   "properties": {

--- a/properties.schema
+++ b/properties.schema
@@ -3,6 +3,26 @@
   "$schema": "http://json-schema.org/draft-04/schema",
   "id": "http://jsonschema.net",
   "required": false,
+  "globals": {
+    "resumeButtonLabel": {
+      "type": "string",
+      "required": true,
+      "default": "Resume",
+      "inputType": "Text",
+      "validators": [],
+      "translatable": true,
+      "help": "Unique element tag label for resume button."
+    },
+    "resumeButtonAriaLabel": {
+      "type": "string",
+      "required": true,
+      "default": "Navigate to your furthest point of progress.",
+      "inputType": "Text",
+      "validators": [],
+      "translatable": true,
+      "help": "Unique element tag ARIA label for resume button."
+    }
+  },
   "properties": {
     "pluginLocations": {
       "type": "object",

--- a/properties.schema
+++ b/properties.schema
@@ -66,7 +66,7 @@
                     ]
                   },
                   "validators": ["required"],
-                  "help": "Allows you to set whether Bookmarking takes learners back to their last previously visited location or your furthest incomplete location. The furthest option will work best in a course with linear progression."
+                  "help": "Allows you to set whether Bookmarking takes learners back to their last previously visited location or your furthest incomplete location. The furthest option will pair best in a course with linear progression."
                 },
                 "_showPrompt": {
                   "type": "boolean",

--- a/properties.schema
+++ b/properties.schema
@@ -49,6 +49,25 @@
                   "validators": ["required"],
                   "help": "Allows you to set whether Bookmarking is done at page, block or component level."
                 },
+                "_location": {
+                  "type": "string",
+                  "required": true,
+                  "enum": [
+                    "previous",
+                    "furthest"
+                  ],
+                  "default": "previous",
+                  "title": "Location",
+                  "inputType": {
+                    "type": "Select",
+                    "options": [
+                      "previous",
+                      "furthest"
+                    ]
+                  },
+                  "validators": ["required"],
+                  "help": "Allows you to set whether Bookmarking takes learners back to their last previously visited location or your furthest incomplete location. The furthest option will work best in a course with linear progression."
+                },
                 "_showPrompt": {
                   "type": "boolean",
                   "required": true,

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -32,7 +32,6 @@
                     "resumeButtonAriaLabel": {
                       "type": "string",
                       "title": "Resume ARIA label",
-                      "description": "ARIA label for ubiquitous resume button.",
                       "default": "Navigate to your furthest point of progress.",
                       "_adapt": {
                         "translatable": true

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -87,6 +87,12 @@
               "description": "Controls whether the Bookmarking prompt is enabled or disabled. If not enabled, the user will be returned to their bookmarked position automatically",
               "default": true
             },
+            "_autoRestore": {
+              "type": "boolean",
+              "title": "Auto restore",
+              "description": "Controls whether the Bookmarking will automatically restore if the prompt is disabled. If not enabled, the user will be not be automatically returned to their bookmarked position.",
+              "default": true
+            },
             "title": {
               "type": "string",
               "title": "Prompt title",

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -21,9 +21,9 @@
                   "title": "Bookmarking",
                   "default": {},
                   "properties": {
-                    "resumeButtonLabel": {
+                    "resumeButtonText": {
                       "type": "string",
-                      "title": "Resume button label",
+                      "title": "Resume button text",
                       "default": "Resume",
                       "_adapt": {
                         "translatable": true

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -34,6 +34,17 @@
               ],
               "_backboneForms": "Select"
             },
+            "_location": {
+              "type": "string",
+              "title": "Location",
+              "description": "Allows you to set whether Bookmarking takes learners back to their last previously visited location or your furthest incomplete location. The furthest option will work best in a course with linear progression.",
+              "default": "previous",
+              "enum": [
+                "previous",
+                "furthest"
+              ],
+              "_backboneForms": "Select"
+            },
             "_showPrompt": {
               "type": "boolean",
               "title": "Enable prompt",

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -37,7 +37,7 @@
             "_location": {
               "type": "string",
               "title": "Location",
-              "description": "Allows you to set whether Bookmarking takes learners back to their last previously visited location or your furthest incomplete location. The furthest option will work best in a course with linear progression.",
+              "description": "Allows you to set whether Bookmarking takes learners back to their last previously visited location or your furthest incomplete location. The furthest option will pair best in a course with linear progression.",
               "default": "previous",
               "enum": [
                 "previous",

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -24,7 +24,6 @@
                     "resumeButtonLabel": {
                       "type": "string",
                       "title": "Resume button label",
-                      "description": "Label for ubiquitous resume button.",
                       "default": "Resume",
                       "_adapt": {
                         "translatable": true

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -7,6 +7,48 @@
       "$ref": "course"
     },
     "with": {
+      "_globals": {
+        "type": "object",
+        "title": "Globals",
+        "default": {},
+        "properties": {
+          "_accessibility": {
+            "type": "object",
+            "title": "Accessibility",
+            "default": {},
+            "required": [
+              "resumeButtonLabel"
+            ],
+            "properties": {
+              "resumeButtonLabel": {
+                "type": "string",
+                "title": "Resume button label",
+                "description": "Unique element tag label for resume button.",
+                "default": "Resume",
+                "_adapt": {
+                  "translatable": true
+                }
+              },
+              "_ariaLabels": {
+                "type": "object",
+                "title": "ARIA labels",
+                "default": {},
+                "properties": {
+                  "resumeButtonAriaLabel": {
+                    "type": "string",
+                    "title": "Resume ARIA label",
+                    "description": "Unique element tag ARIA label for resume button.",
+                    "default": "Navigate to your furthest point of progress.",
+                    "_adapt": {
+                      "translatable": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
       "properties": {
         "_bookmarking": {
           "type": "object",

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -7,49 +7,44 @@
       "$ref": "course"
     },
     "with": {
-      "_globals": {
-        "type": "object",
-        "title": "Globals",
-        "default": {},
-        "properties": {
-          "_accessibility": {
-            "type": "object",
-            "title": "Accessibility",
-            "default": {},
-            "required": [
-              "resumeButtonLabel"
-            ],
-            "properties": {
-              "resumeButtonLabel": {
-                "type": "string",
-                "title": "Resume button label",
-                "description": "Unique element tag label for resume button.",
-                "default": "Resume",
-                "_adapt": {
-                  "translatable": true
-                }
-              },
-              "_ariaLabels": {
-                "type": "object",
-                "title": "ARIA labels",
-                "default": {},
-                "properties": {
-                  "resumeButtonAriaLabel": {
-                    "type": "string",
-                    "title": "Resume ARIA label",
-                    "description": "Unique element tag ARIA label for resume button.",
-                    "default": "Navigate to your furthest point of progress.",
-                    "_adapt": {
-                      "translatable": true
+      "properties": {
+        "_globals": {
+          "type": "object",
+          "default": {},
+          "properties": {
+            "_extensions": {
+              "type": "object",
+              "default": {},
+              "properties": {
+                "_bookmarking": {
+                  "type": "object",
+                  "title": "Bookmarking",
+                  "default": {},
+                  "properties": {
+                    "resumeButtonLabel": {
+                      "type": "string",
+                      "title": "Resume button label",
+                      "description": "Label for ubiquitous resume button.",
+                      "default": "Resume",
+                      "_adapt": {
+                        "translatable": true
+                      }
+                    },
+                    "resumeButtonAriaLabel": {
+                      "type": "string",
+                      "title": "Resume ARIA label",
+                      "description": "ARIA label for ubiquitous resume button.",
+                      "default": "Navigate to your furthest point of progress.",
+                      "_adapt": {
+                        "translatable": true
+                      }
                     }
                   }
                 }
               }
             }
           }
-        }
-      },
-      "properties": {
+        },
         "_bookmarking": {
           "type": "object",
           "title": "Bookmarking",

--- a/templates/bookmarkingResume.jsx
+++ b/templates/bookmarkingResume.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export default function Bookmarking(props) {
+  const {
+    label,
+    ariaLabel
+  } = props;
+  return (
+    <div className="bookmarking-resume__inner">
+      <button
+        className='btn-text bookmarking-resume__button js-bookmarking-resume-button'
+        aria-label={ariaLabel} >
+        {label}
+      </button>
+    </div>
+  );
+}

--- a/templates/bookmarkingResume.jsx
+++ b/templates/bookmarkingResume.jsx
@@ -13,7 +13,7 @@ export default function Bookmarking(props) {
         type='button'
         className={classes([
           'btn-text bookmarking-resume__button js-bookmarking-resume-button',
-          isDisabled
+          isDisabled && 'is-disabled'
         ])}
         aria-disabled={isDisabled || null}
         aria-label={ariaLabel} >

--- a/templates/bookmarkingResume.jsx
+++ b/templates/bookmarkingResume.jsx
@@ -1,15 +1,21 @@
 import React from 'react';
+import { classes } from 'core/js/reactHelpers';
 
 export default function Bookmarking(props) {
   const {
     label,
-    ariaLabel
+    ariaLabel,
+    isDisabled
   } = props;
   return (
     <div className="bookmarking-resume__inner">
       <button
         type='button'
-        className='btn-text bookmarking-resume__button js-bookmarking-resume-button'
+        className={classes([
+          'btn-text bookmarking-resume__button js-bookmarking-resume-button',
+          isDisabled
+        ])}
+        aria-disabled={isDisabled || null}
         aria-label={ariaLabel} >
         {label}
       </button>

--- a/templates/bookmarkingResume.jsx
+++ b/templates/bookmarkingResume.jsx
@@ -8,6 +8,7 @@ export default function Bookmarking(props) {
   return (
     <div className="bookmarking-resume__inner">
       <button
+        type='button'
         className='btn-text bookmarking-resume__button js-bookmarking-resume-button'
         aria-label={ariaLabel} >
         {label}


### PR DESCRIPTION
fixes #63 

### Delete
* Removes redundant return in navigateCancel function

### New
* Allows to set whether Bookmarking takes learners back to their last previously visited location or your furthest incomplete location with a new JSON field, "_location". The furthest option will pair best in a course with linear progression.
* Uses the new [DOM Element Modification API](https://github.com/adaptlearning/adapt-contrib-core/releases/tag/v6.38.0) to allow the inclusion of a unique element tag, `<bookmarking />`. This will add a button into any compiled JSON field. This button will always navigate learners to their furthest point of progression according to model data.
* The labels for the button will pull data from the following locations in this order: Button Attribute, Adapt Course Globals, Button Inner HTML

[//]: # (List appropriate steps for testing if needed)
### Testing
1. After installation, test both level settings "furthest" & "previous" while connected to an LMS. Ensure the bookmarking notify prompt is navigating you to the appropriate location.
2. Place the `<bookmarking />` tag in any compiled JSON field and test that it is taking you to your furthest point of progression.

