### PR TITLE
Fix: Title is required to set notify popup dialog label (fixes #65)

### DIFF
--- a/properties.schema
+++ b/properties.schema
@@ -61,7 +61,7 @@
                 "title": {
                   "type": "string",
                   "default": "Bookmarking",
-                  "required": false,
+                  "required": true,
                   "title": "Prompt Title",
                   "inputType": "Text",
                   "validators": [],

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -13,7 +13,8 @@
           "title": "Bookmarking",
           "default": {},
           "required": [
-            "_level"
+            "_level",
+            "title"
           ],
           "properties": {
             "_isEnabled": {


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-bookmarking/issues/65

### Fix
* Set `title` as `required`. Without a title, the popup `dialog` won't be properly identified by assistive technologies.



