### PR TITLE
issue/63 review

### DIFF
--- a/example.json
+++ b/example.json
@@ -6,6 +6,7 @@
         "_comment": "_location can be set to previous or furthest",
         "_location": "previous",
         "_showPrompt": true,
+        "_autoRestore": true,
         "title": "Bookmarking",
         "body": "Would you like to continue where you left off?",
         "_buttons": {

--- a/example.json
+++ b/example.json
@@ -24,4 +24,4 @@
     // Unique element tag placement. Place a button in any compiled json field (e.g. attribute, displayTitle, body, instruction, etc)
     "body": "<bookmarking />",
     // Attribute labels that override course.json
-    "body": "<bookmarking label='Resume course' aria-label='Navigate to your furthest point of progress.' />",
+    "body": "<bookmarking location='furthest' label='Resume course' aria-label='Navigate to your furthest point of progress.' />",

--- a/example.json
+++ b/example.json
@@ -24,4 +24,5 @@
     // Unique element tag placement. Place a button in any compiled json field (e.g. attribute, displayTitle, body, instruction, etc)
     "body": "<bookmarking />",
     // Attribute labels that override course.json
-    "body": "<bookmarking location='furthest' label='Resume course' aria-label='Navigate to your furthest point of progress.' />",
+    "body": "<bookmarking location='previous' label='Resume' aria-label='Continue where you left off.' />",
+    "body": "<bookmarking location='furthest' label='Continue' aria-label='Navigate to your furthest point of progress.' />",

--- a/js/BookmarkingModel.js
+++ b/js/BookmarkingModel.js
@@ -3,7 +3,8 @@ export default class BookmarkingModel extends Backbone.Model {
   defaults () {
     return {
       label: '',
-      ariaLabel: ''
+      ariaLabel: '',
+      _location: 'previous'
     };
   }
 

--- a/js/BookmarkingView.js
+++ b/js/BookmarkingView.js
@@ -42,6 +42,6 @@ export default class BookmarkingView extends Backbone.View {
   }
 
   onResumeClicked() {
-    Adapt.trigger('bookmarking:resume');
+    Adapt.trigger('bookmarking:resume', this.model.get('_location'));
   }
 }

--- a/js/adapt-contrib-bookmarking.js
+++ b/js/adapt-contrib-bookmarking.js
@@ -148,8 +148,7 @@ class Bookmarking extends Backbone.Controller {
   }
 
   showPrompt() {
-    const courseBookmarkModel = this.config;
-    const buttons = courseBookmarkModel._buttons || { yes: 'Yes', no: 'No' };
+    const buttons = this.config._buttons || { yes: 'Yes', no: 'No' };
     this.listenToOnce(Adapt, {
       'bookmarking:continue': this.navigateTo,
       'bookmarking:cancel': this.navigateCancel
@@ -157,8 +156,8 @@ class Bookmarking extends Backbone.Controller {
     notify.prompt({
       _classes: 'is-bookmarking',
       _showIcon: true,
-      title: courseBookmarkModel.title,
-      body: courseBookmarkModel.body,
+      title: this.config.title,
+      body: this.config.body,
       _prompts: [
         {
           promptText: buttons.yes || 'Yes',

--- a/js/adapt-contrib-bookmarking.js
+++ b/js/adapt-contrib-bookmarking.js
@@ -47,7 +47,7 @@ class Bookmarking extends Backbone.Controller {
   }
 
   get furthestIncompleteModel() {
-    const bookmarkLevel = Adapt.course.get('_bookmarking')._level || 'component';
+    const bookmarkLevel = this.config._level || 'component';
     const getIncompleteModels = Adapt.course.findDescendantModels(bookmarkLevel, { where: { _isComplete: false, _isAvailable: true, _isOptional: false } });
     const furthestIncompleteModel = getIncompleteModels.at(0);
     return furthestIncompleteModel;
@@ -60,7 +60,7 @@ class Bookmarking extends Backbone.Controller {
   }
 
   checkCourseIsEnabled() {
-    const courseBookmarkModel = Adapt.course.get('_bookmarking');
+    const courseBookmarkModel = this.config;
     if (!courseBookmarkModel || !courseBookmarkModel._isEnabled) return false;
     return true;
   }
@@ -121,8 +121,9 @@ class Bookmarking extends Backbone.Controller {
   restoreLocation() {
     this.stopListening(Adapt, 'pageView:ready menuView:ready', this.restoreLocation);
     _.delay(() => {
+      if (this.config._autoRestore === false) return;
       if (this.isAlreadyOnScreen(this.restoredLocationID)) return;
-      if (Adapt.course.get('_bookmarking')._showPrompt === false) {
+      if (this.config._showPrompt === false) {
         this.navigateTo();
         return;
       }
@@ -147,7 +148,7 @@ class Bookmarking extends Backbone.Controller {
   }
 
   showPrompt() {
-    const courseBookmarkModel = Adapt.course.get('_bookmarking');
+    const courseBookmarkModel = this.config;
     const buttons = courseBookmarkModel._buttons || { yes: 'Yes', no: 'No' };
     this.listenToOnce(Adapt, {
       'bookmarking:continue': this.navigateTo,
@@ -213,7 +214,7 @@ class Bookmarking extends Backbone.Controller {
    * @return {String} Either 'page', 'block', or 'component' - with 'component' being the default
    */
   getBookmarkLevel(pageModel) {
-    const defaultLevel = Adapt.course.get('_bookmarking')._level || 'component';
+    const defaultLevel = this.config._level || 'component';
     const bookmarkModel = pageModel.get('_bookmarking');
     const isInherit = !bookmarkModel || !bookmarkModel._level || bookmarkModel._level === 'inherit';
     return isInherit ? defaultLevel : bookmarkModel._level;

--- a/properties.schema
+++ b/properties.schema
@@ -97,6 +97,15 @@
                   "validators": [],
                   "help": "Controls whether the Bookmarking prompt is enabled or disabled. If not enabled, the user will be returned to their bookmarked position automatically."
                 },
+                "_autoRestore": {
+                  "type": "boolean",
+                  "required": true,
+                  "default": true,
+                  "title": "Auto restore",
+                  "inputType": "Checkbox",
+                  "validators": [],
+                  "help": "Controls whether the Bookmarking will automatically restore if the prompt is disabled. If not enabled, the user will be not be automatically returned to their bookmarked position."
+                },
                 "title": {
                   "type": "string",
                   "default": "Bookmarking",

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -87,6 +87,12 @@
               "description": "Controls whether the Bookmarking prompt is enabled or disabled. If not enabled, the user will be returned to their bookmarked position automatically",
               "default": true
             },
+            "_autoRestore": {
+              "type": "boolean",
+              "title": "Auto restore",
+              "description": "Controls whether the Bookmarking will automatically restore if the prompt is disabled. If not enabled, the user will be not be automatically returned to their bookmarked position.",
+              "default": true
+            },
             "title": {
               "type": "string",
               "title": "Prompt title",

--- a/templates/bookmarkingResume.jsx
+++ b/templates/bookmarkingResume.jsx
@@ -13,7 +13,7 @@ export default function Bookmarking(props) {
         type='button'
         className={classes([
           'btn-text bookmarking-resume__button js-bookmarking-resume-button',
-          isDisabled
+          isDisabled && 'is-disabled'
         ])}
         aria-disabled={isDisabled || null}
         aria-label={ariaLabel} >


### PR DESCRIPTION
* Allow button to override location with `location='furthest'`
* Added button location override to examples.json
* Renamed `navigateToId` getter to `getLocationId(location)` function and `navigateToId` variables to `id`
* Moved `is-disabled` class from `isDisabled` boolean variable into the template
* Added `_autoRestore` to allow control through buttons only when `_showPrompt: false`


