### PR TITLE
Fix: respect locked content when returning to location (fixes #51)

### DIFF
--- a/js/adapt-contrib-bookmarking.js
+++ b/js/adapt-contrib-bookmarking.js
@@ -196,9 +196,8 @@ class Bookmarking extends Backbone.Controller {
     
     if (!isPrecededByLockedContent && !isLockedContentObject) return id;
 
-    const offset = isContentObject ? 0 : 1;
     const nearestUnlockedIndex = precedingModels.reverse().findIndex(precedingModel => !precedingModel.get('_isLocked'));
-    return precedingModels[nearestUnlockedIndex + offset].get('_id');
+    return precedingModels[nearestUnlockedIndex].get('_id');
   }
 
   navigateTo(location = this.location) {

--- a/js/adapt-contrib-bookmarking.js
+++ b/js/adapt-contrib-bookmarking.js
@@ -206,7 +206,7 @@ class Bookmarking extends Backbone.Controller {
     if (['', undefined, 'current'].includes(id)) return;
     _.defer(async () => {
       try {
-        const target = this.getAppropriateReturnPath(id);
+        const target = this.resolveLocking(id);
 
         const isSinglePage = (Adapt.contentObjects.models.length === 1);
         await router.navigateToElement(target, { trigger: true, replace: isSinglePage, duration: 400 });

--- a/js/adapt-contrib-bookmarking.js
+++ b/js/adapt-contrib-bookmarking.js
@@ -202,8 +202,9 @@ class Bookmarking extends Backbone.Controller {
 
   navigateTo(location = this.location) {
     const id = this.getLocationId(location);
+    if (['', undefined, 'current'].includes(id)) return;
     const target = this.resolveLocking(id);
-    if (['', undefined, 'current'].includes(target)) return;
+    if (!target) return;
     _.defer(async () => {
       try {
 


### PR DESCRIPTION
#51 

### Fix
* respect locked content when returning to location

### Notes

If the bookmark is of type contentobject and the location is locked or preceded by locked content then the user is returned to the nearest unlocked contentobject prior to the location.

If the bookmark is of type article/block/component and the location is preceded by locked content then the user is returned to the nearest point prior to the location that is not itself preceded by locked content.